### PR TITLE
Improve performance for many-executor systems

### DIFF
--- a/src/main/java/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper.java
+++ b/src/main/java/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper.java
@@ -41,12 +41,9 @@ public class LogfilesizecheckerWrapper extends SimpleBuildWrapper implements Ser
 
     /** Fail the build rather than aborting it. */
     public boolean failBuild;
-    
-    /**Period for timer task that checks the logfile size.*/
-    private static final long PERIOD = 1000L;
 
     /**Delay for timer task that checks the logfile size.*/
-    private static final long DELAY = 1000L;
+    private static final long DELAY = 1;
 
     /**Conversion factor for Mega Bytes.*/
     private static final long MB = 1024L * 1024L;
@@ -78,7 +75,8 @@ public class LogfilesizecheckerWrapper extends SimpleBuildWrapper implements Ser
         if (allowedLogSize > 0) {
             LogSizeTimerTask logSizeTimerTask =
                     new LogSizeTimerTask(build, listener, allowedLogSize, failBuild);
-            Timer.get().scheduleAtFixedRate(logSizeTimerTask, DELAY, PERIOD, TimeUnit.MILLISECONDS);
+            Timer.get().scheduleAtFixedRate(logSizeTimerTask, DELAY,
+                    DESCRIPTOR.getCheckPeriod(), TimeUnit.SECONDS);
             context.setDisposer(new LogSizeTimerTaskDisposer(logSizeTimerTask));
         }
     }
@@ -153,6 +151,9 @@ public class LogfilesizecheckerWrapper extends SimpleBuildWrapper implements Ser
         /**If there is no job specific size set, this will be used.*/
         private int defaultLogSize;
 
+        /**The delay between successive checks.*/
+        private int checkPeriod = 1;
+
         /**Constructor loads previously saved form data.*/
         DescriptorImpl() {
             super(LogfilesizecheckerWrapper.class);
@@ -192,18 +193,24 @@ public class LogfilesizecheckerWrapper extends SimpleBuildWrapper implements Ser
         }
 
         /**
+         * Returns the period, in seconds, between successive checks.
+         * @return the globally set period between checks
+         */
+        public int getCheckPeriod() {
+            return checkPeriod;
+        }
+
+        /**
          * 
          * 
          * {@inheritDoc}
          */
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             final String size = formData.getString("defaultLogSize");
+            final String delay = formData.getString("checkPeriod");
 
-            if (size != null) {
-                defaultLogSize = Integer.parseInt(size);
-            } else {
-                defaultLogSize = 0;
-            }
+            defaultLogSize = size != null ? Integer.parseInt(size) : 0;
+            checkPeriod = delay != null ? Integer.parseInt(delay) : 1;
             save();
             return super.configure(req, formData);
         }

--- a/src/main/java/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper.java
+++ b/src/main/java/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper.java
@@ -107,13 +107,13 @@ public class LogfilesizecheckerWrapper extends SimpleBuildWrapper implements Ser
 
         /**Interrupts build if log file is too big.*/
         public void doRun() {
-            final Executor e = build.getExecutor();
-            if (e != null
-                    && build.getLogFile().length() > allowedLogSize * MB
-                    && !e.isInterrupted()) {
-                listener.getLogger().println(
-                        ">>> Max Log Size reached "+allowedLogSize+"(MB). Aborting <<<");
-                e.interrupt(failBuild ? Result.FAILURE : Result.ABORTED);
+            if (build.getLogFile().length() > allowedLogSize * MB) {
+                final Executor e = build.getExecutor();
+                if (e != null && !e.isInterrupted()) {
+                    listener.getLogger().println(
+                            ">>> Max Log Size reached "+allowedLogSize+"(MB). Aborting <<<");
+                    e.interrupt(failBuild ? Result.FAILURE : Result.ABORTED);
+                }
             }
         }
     }

--- a/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/global.jelly
+++ b/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/global.jelly
@@ -4,5 +4,8 @@
        <f:entry title="${%Max Log Size in MB}" field="defaultLogSize">
           <f:textbox value="${it.getDefaultLogSize()}"/>
        </f:entry>
+       <f:entry title="${%Check frequency in seconds}" field="checkPeriod">
+          <f:textbox value="${it.getDefaultDelay()}"/>
+       </f:entry>
     </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/global_de.properties
+++ b/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/global_de.properties
@@ -1,2 +1,3 @@
 Abort\ Build\ if\ log\ file\ gets\ too\ big=Build\ abbrechen\ wenn\ Logdatei\ zu\ groß
 Max\ Log\ Size\ in\ MB=Maximale\ Logdateigröße\ in\ MB
+Size\ check\ frequency\ in\ seconds=Zeitverzögerung\ in\ Sekunden\ zwischen\ Kontrollen

--- a/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/help-checkPeriod.html
+++ b/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/help-checkPeriod.html
@@ -1,0 +1,6 @@
+<div>
+  The size of the accumulated log file is checked regularly. This setting
+  can be used to customize the frequency of such checks; the lower it is,
+  the quicker builds will abort after exceeding the limit. However, setting
+  it too low can incur significant computational costs.
+</div>

--- a/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/help-checkPeriod_de.html
+++ b/src/main/resources/hudson/plugins/logfilesizechecker/LogfilesizecheckerWrapper/help-checkPeriod_de.html
@@ -1,0 +1,6 @@
+<div>
+  Die Größe der akkumulierten Protokolldatei wird regelmäßig überprüft. Mit dieser Einstellung
+  kann die Häufigkeit solcher Prüfungen angepasst werden; je niedriger der Wert ist ist,
+  desto schneller werden Builds nach dem Überschreiten des Limits abgebrochen.
+  Ein zu niedriger Wert kann erhebliche rechnerische Kosten verursachen.
+</div>


### PR DESCRIPTION
With current Jenkins core, calling `build.getExecutor()` (and `hudson.model.Executor.of()`) is surprisingly expensive, because it iterates over `Jenkins::getComputers` to find the matching executor with a linear scan. That method constructs a snapshot copy of the current list of slaves, and sorts it, with the sort comparison also being asymptotically quite slow. The result is that scheduling a timer task every second to check log sizes on a Jenkins instance with dozens or hundreds of executors leads to unsustainable CPU usage and starvation.

The first commit here observes that we don't actually need the value of `build.getExecutor()` until we know we want to abort a build, which is a comparatively rare occurrence, and so we can just delay calling it until we know we need to.

The second commit adds a global setting for the desired frequency of log file size checks. Setting it higher will reduce CPU load, at the cost of allowing log files to grow further above the configured limit before builds being aborted.

This had quite a dramatic effect on our Jenkins instance. The drop in CPU usage corresponds to the first commit being deployed:

![image](https://user-images.githubusercontent.com/1101487/42933302-6139e910-8b3c-11e8-898e-69f4cfb1f7c2.png)
